### PR TITLE
使っていないコルーチンスコープの削除

### DIFF
--- a/Raichou/app/src/main/java/dev/mixi/raichou/HomeListFragment.kt
+++ b/Raichou/app/src/main/java/dev/mixi/raichou/HomeListFragment.kt
@@ -10,14 +10,11 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import androidx.navigation.Navigation
 import dev.mixi.raichou.databinding.FragmentHomeListBinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.cancel
 
 /**
  * A simple [Fragment] subclass.
  */
-class HomeListFragment : Fragment(), CoroutineScope by MainScope() {
+class HomeListFragment : Fragment() {
 
     val viewModel by viewModels<HomeListViewModel>()
     lateinit var binding: FragmentHomeListBinding
@@ -42,10 +39,5 @@ class HomeListFragment : Fragment(), CoroutineScope by MainScope() {
                 submitList(list)
             }
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        cancel()
     }
 }

--- a/Raichou/app/src/main/java/dev/mixi/raichou/MainActivity.kt
+++ b/Raichou/app/src/main/java/dev/mixi/raichou/MainActivity.kt
@@ -4,10 +4,8 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import dev.mixi.raichou.databinding.ActivityMainBinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
 
-class MainActivity : AppCompatActivity(), CoroutineScope by MainScope() {
+class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/Raichou/app/src/main/java/dev/mixi/raichou/MediumPostFragment.kt
+++ b/Raichou/app/src/main/java/dev/mixi/raichou/MediumPostFragment.kt
@@ -12,15 +12,12 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.observe
 import com.google.android.material.snackbar.Snackbar
 import dev.mixi.raichou.databinding.FragmentMediumPostBinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.cancel
 import timber.log.Timber
 
 /**
  * A simple [Fragment] subclass.
  */
-class MediumPostFragment : Fragment(), CoroutineScope by MainScope() {
+class MediumPostFragment : Fragment() {
 
     lateinit var binding: FragmentMediumPostBinding
     val viewModel by viewModels<MediumPostViewModel>()
@@ -55,11 +52,6 @@ class MediumPostFragment : Fragment(), CoroutineScope by MainScope() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         showListWithPermissionCheck()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        cancel()
     }
 
     fun post() {


### PR DESCRIPTION
ViewModelにコルーチンの処理を移したので、とりあえず必要なくなったので消しておきました。
`fragment-ktx:1.2.0-alpha01`のlifecycleScope.launchWhenStartedを使うことで一応同じような処理が可能になります。
https://developer.android.com/topic/libraries/architecture/coroutines